### PR TITLE
Adds single request subscription model (NOT FOR MERGING)

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -11,6 +11,7 @@ using System.Net.Sockets;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Authentication;
+using System.Globalization;
 
 // disable XML comment warnings
 #pragma warning disable 1591
@@ -99,6 +100,62 @@ namespace NATS.Client
         Timer               ptmr = null;
 
         int                 pout = 0;
+
+        private AsyncSubscription globalRequestSubscription;
+        private TaskCompletionSource<object> globalRequestSubReady;
+        private string globalRequestInbox;
+
+        // used to map replies to requests from client (should lock)
+        private long nextRequestId = 0;
+
+        private Dictionary<string, InFlightRequest> waitingRequests = 
+            new Dictionary<string, InFlightRequest>(StringComparer.OrdinalIgnoreCase);
+
+        // Handles in-flight requests when using the new-style request/reply behavior
+        private sealed class InFlightRequest
+        {
+            public InFlightRequest(CancellationToken token, int timeout)
+            {
+                this.Waiter = new TaskCompletionSource<Msg>();
+                if (token != default(CancellationToken))
+                {
+                    token.Register(() => this.Waiter.TrySetCanceled());
+
+                    if (timeout > 0)
+                    {
+                        var timeoutToken = new CancellationTokenSource();
+
+                        var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                            timeoutToken.Token, token);
+                        this.Token = linkedTokenSource.Token;
+
+                        timeoutToken.Token.Register(
+                            () => this.Waiter.TrySetException(new NATSTimeoutException()));
+                        timeoutToken.CancelAfter(timeout);
+                    }
+                    else
+                    {
+                        this.Token = token;
+                    }
+                }
+                else
+                {
+                    if (timeout > 0)
+                    {
+                        var timeoutToken = new CancellationTokenSource();
+                        this.Token = timeoutToken.Token;
+
+                        timeoutToken.Token.Register(
+                            () => this.Waiter.TrySetException(new NATSTimeoutException()));
+                        timeoutToken.CancelAfter(timeout);
+                    }
+                }
+            }
+
+            public string Id { get; set; }
+            public CancellationToken Token { get; }
+            public TaskCompletionSource<Msg> Waiter { get; }
+        }
 
         // Prepare protocol messages for efficiency
         private byte[] PING_P_BYTES = null;
@@ -2191,6 +2248,157 @@ namespace NATS.Client
 
         internal virtual Msg request(string subject, byte[] data, int timeout)
         {
+            if (!opts.UseOldRequestStyle)
+            {
+                var request = requestSync(subject, data, timeout, CancellationToken.None);
+
+                Flush(timeout > 0 ? timeout : DEFAULT_FLUSH_TIMEOUT);
+                request.Waiter.Task.Wait(timeout);
+
+                return request.Waiter.Task.Result;
+            }
+            else
+            {
+                return oldRequest(subject, data, timeout);
+            }
+        }
+
+        private InFlightRequest setupRequest(int timeout, CancellationToken token)
+        {
+            InFlightRequest request = new InFlightRequest(token, timeout);
+            bool createSub = false;
+            lock (mu)
+            {
+                if (globalRequestSubReady == null)
+                {
+                    globalRequestSubReady = new TaskCompletionSource<object>();
+
+                    globalRequestInbox = NewInbox();
+
+                    createSub = true;
+                }
+
+                if (nextRequestId < 0)
+                {
+                    nextRequestId = 0;
+                }
+
+                request.Id = (nextRequestId++).ToString(CultureInfo.InvariantCulture);
+
+                waitingRequests.Add(
+                    request.Id,
+                    request);
+            }
+
+            if (createSub)
+            {
+                globalRequestSubscription = subscribeAsync(globalRequestInbox + ".*", null, requestResponseHandler);
+
+                globalRequestSubReady.TrySetResult(null);
+            }
+
+            return request;
+        }
+
+        private InFlightRequest requestSync(string subject, byte[] data, int timeout, CancellationToken token)
+        {
+            InFlightRequest request = setupRequest(timeout, token);
+
+            request.Token.ThrowIfCancellationRequested();
+
+            if (globalRequestSubscription == null)
+                globalRequestSubReady.Task.Wait(timeout, request.Token);
+
+            token.ThrowIfCancellationRequested();
+
+            publish(subject, globalRequestInbox + "." + request.Id, data);
+
+            return request;
+        }
+
+        private Task<Msg> requestAsync(string subject, byte[] data, int timeout, CancellationToken token)
+        {
+            return Task.Run(
+                async () =>
+                {
+                    InFlightRequest request = setupRequest(timeout, token);
+
+                    request.Token.ThrowIfCancellationRequested();
+
+                    if (globalRequestSubscription == null)
+                        await globalRequestSubReady.Task;
+
+                    publish(subject, globalRequestInbox + "." + request.Id, data);
+
+                    Flush(timeout > 0 ? timeout : DEFAULT_FLUSH_TIMEOUT);
+
+                    // InFlightRequest links the token cancellation
+                    return await request.Waiter.Task;
+                },
+                token);
+        }
+
+        private static Task WaitOnHandleAsync(WaitHandle handle, int timeout, CancellationToken token)
+        {
+            var tcs = new TaskCompletionSource<object>();
+            var registration = ThreadPool.RegisterWaitForSingleObject(
+                handle,
+                (state, timedOut) =>
+                {
+                    var localTcs = (TaskCompletionSource<object>)state;
+                    if (timedOut || token.IsCancellationRequested)
+                    {
+                        localTcs.TrySetCanceled();
+                    }
+                    else
+                    {
+                        localTcs.TrySetResult(null);
+                    }
+                },
+                tcs,
+                timeout,
+                executeOnlyOnce: true);
+            tcs.Task.ContinueWith((_, state) => ((RegisteredWaitHandle)state).Unregister(null), registration, TaskScheduler.Default);
+            return tcs.Task;
+        }
+
+        private void requestResponseHandler(object sender, MsgHandlerEventArgs e)
+        {
+            //               \
+            //               \/
+            //  _INBOX.<nuid>.<requestId>
+            string requestId = e.Message.Subject.Substring(globalRequestInbox.Length + 1);
+            if (e.Message == null)
+            {
+                return;
+            }
+
+            bool isClosed;
+            InFlightRequest request;
+            lock (mu)
+            {
+                isClosed = this.isClosed();
+
+                if (!waitingRequests.TryGetValue(requestId, out request))
+                {
+                    return;
+                }
+
+                waitingRequests.Remove(requestId);
+            }
+
+            if (!isClosed)
+            {
+                request.Waiter.SetResult(e.Message);
+            }
+            else
+            {
+                request.Waiter.SetCanceled();
+            }
+        }
+
+        private Msg oldRequest(string subject, byte[] data, int timeout)
+        {
             Msg    m     = null;
             string inbox = NewInbox();
 
@@ -2223,18 +2431,18 @@ namespace NATS.Client
             return request(subject, data, -1);
         }
 
-        internal virtual Task<Msg> requestAsync(string subject, byte[] data, int timeout)
+        internal virtual Task<Msg> oldRequestAsync(string subject, byte[] data, int timeout)
         {
             // Simple case without a cancellation token.
-            return Task.Factory.StartNew<Msg>(() => { return request(subject, data, timeout); });
+            return Task.Factory.StartNew<Msg>(() => { return oldRequest(subject, data, timeout); });
         }
 
-        internal virtual Task<Msg> requestAsync(string subject, byte[] data, int timeout, CancellationToken ct)
+        internal virtual Task<Msg> oldRequestAsync(string subject, byte[] data, int timeout, CancellationToken ct)
         {
             // Simple case without a cancellation token.
             if (ct == null)
             {
-                return Task.Factory.StartNew<Msg>(() => { return request(subject, data, timeout); });
+                return Task.Factory.StartNew<Msg>(() => { return oldRequest(subject, data, timeout); });
             }
 
             // More complex case, supporting cancellation.
@@ -2314,12 +2522,26 @@ namespace NATS.Client
                     "timeout");
             }
 
-            return requestAsync(subject, data, timeout);
+            if (!opts.UseOldRequestStyle)
+            {
+                return requestAsync(subject, data, timeout, CancellationToken.None);
+            }
+            else
+            {
+                return oldRequestAsync(subject, data, timeout);
+            }
         }
 
         public Task<Msg> RequestAsync(string subject, byte[] data)
         {
-            return requestAsync(subject, data, -1);
+            if (!opts.UseOldRequestStyle)
+            {
+                return requestAsync(subject, data, -1, CancellationToken.None);
+            }
+            else
+            {
+                return oldRequestAsync(subject, data, -1);
+            }
         }
 
         public Task<Msg> RequestAsync(string subject, byte[] data, int timeout, CancellationToken token)
@@ -2328,28 +2550,49 @@ namespace NATS.Client
             if (timeout <= 0)
             {
                 throw new ArgumentException(
-                    "Timeout must be greater that 0.",
+                    "Timeout must be greater than 0.",
                     "timeout");
             }
 
-            return requestAsync(subject, data, timeout, token);
+            if (!opts.UseOldRequestStyle)
+            {
+                return requestAsync(subject, data, timeout, token);
+            }
+            else
+            {
+                return oldRequestAsync(subject, data, timeout, token);
+            }
         }
 
         public Task<Msg> RequestAsync(string subject, byte[] data, CancellationToken token)
         {
-            return requestAsync(subject, data, -1, token);
+            if (!opts.UseOldRequestStyle)
+            {
+                return requestAsync(subject, data, -1, token);
+            }
+            else
+            {
+                return oldRequestAsync(subject, data, -1, token);
+            }
         }
 
         public string NewInbox()
         {
-            if (r == null)
-                r = new Random(Guid.NewGuid().GetHashCode());
+            if (!opts.UseOldRequestStyle)
+            {
+                return IC.inboxPrefix + Guid.NewGuid().ToString("N");
+            }
+            else
+            {
+                if (r == null)
+                    r = new Random(Guid.NewGuid().GetHashCode());
 
-            byte[] buf = new byte[13];
+                byte[] buf = new byte[13];
 
-            r.NextBytes(buf);
+                r.NextBytes(buf);
 
-            return IC.inboxPrefix + BitConverter.ToString(buf).Replace("-", "");
+                return IC.inboxPrefix + BitConverter.ToString(buf).Replace("-","");
+            }
         }
 
         internal void sendSubscriptionMessage(AsyncSubscription s)
@@ -2673,6 +2916,19 @@ namespace NATS.Client
         }
 
 
+        // Clears any in-flight requests by cancelling them all
+        // Caller must lock
+        private void clearPendingRequestCalls()
+        {
+            foreach (var request in waitingRequests)
+            {
+                request.Value.Waiter.TrySetCanceled();
+            }
+
+            waitingRequests.Clear();
+        }
+
+
         // Low level close call that will do correct cleanup and set
         // desired status. Also controls whether user defined callbacks
         // will be triggered. The lock should not be held entering this
@@ -2700,6 +2956,9 @@ namespace NATS.Client
                 clearPendingFlushCalls();
                 if (pending != null)
                     pending.Dispose();
+
+                // Clear any pending request calls
+                clearPendingRequestCalls();
 
                 stopPingTimer();
 

--- a/NATS.Client/Options.cs
+++ b/NATS.Client/Options.cs
@@ -19,6 +19,7 @@ namespace NATS.Client
         string name = null;
         bool verbose = false;
         bool pedantic = false;
+        bool useOldRequestStyle = false;
         bool secure = false;
         bool allowReconnect = true;
         int maxReconnect  = Defaults.MaxReconnect;
@@ -92,6 +93,7 @@ namespace NATS.Client
 
             noRandomize = o.noRandomize;
             pedantic = o.pedantic;
+            useOldRequestStyle = o.useOldRequestStyle;
             pingInterval = o.pingInterval;
             ReconnectedEventHandler = o.ReconnectedEventHandler;
             reconnectWait = o.reconnectWait;
@@ -191,6 +193,23 @@ namespace NATS.Client
         {
             get { return pedantic; }
             set { pedantic = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the old
+        /// request pattern should be used.
+        /// </summary>
+        /// <remarks>
+        /// The old request pattern involved a separate subscription
+        /// per request inbox. The new style (default) involves creating
+        /// a single inbox subscription per connection, upon the first
+        /// request, and mapping outbound requests over that one
+        /// subscription.
+        /// </remarks>
+        public bool UseOldRequestStyle
+        {
+            get { return useOldRequestStyle; }
+            set { useOldRequestStyle = value; }
         }
 
         /// <summary>
@@ -430,6 +449,7 @@ namespace NATS.Client
             sb.AppendFormat("Name={0};", Name == null ? Name : "null");
             sb.AppendFormat("NoRandomize={0};", NoRandomize);
             sb.AppendFormat("Pendantic={0};", Pedantic);
+            sb.AppendFormat("UseOldRequestStyle={0}", UseOldRequestStyle);
             sb.AppendFormat("PingInterval={0};", PingInterval);
             sb.AppendFormat("ReconnectWait={0};", ReconnectWait);
             sb.AppendFormat("Secure={0};", Secure);


### PR DESCRIPTION
Adds the single request subscription model, covered by `Options.UseOldRequestStyle` (which defaults to `false`). This tracks https://github.com/nats-io/csharp-nats/issues/158 and uses the same general flow as found in https://github.com/nats-io/go-nats/pull/295

To support both cancellation and timeouts, a linked token source is created and managed by the new `InFlightRequest` class internal to the connection.

Performance (including #2 and relative to master):

`opts.UseOldRequestStyle=true`
```
                         | Baseline         | ReqReply (Old) | Delta          | Speedup   
-----------------|-------|----------|-------|----------------|--------|-------|---------|-----
                 | Count | msgs/s   | kb/s  | msgs/s | kb/s  | msgs/s | kb/s  | msgs/s  | kb/s
ReqReplNo        | 20000 | 4447     | 0     | 6752   | 0     | 2305   | 0     | 1.52    |     
ReqRepl8b        | 10000 | 4080     | 31    | 7167   | 55    | 3087   | 24    | 1.76    | 1.77
ReqRepl32b       | 10000 | 3905     | 122   | 6394   | 199   | 2489   | 77    | 1.64    | 1.63
ReqRepl256b      | 5000  | 3912     | 978   | 5418   | 1354  | 1506   | 376   | 1.38    | 1.38
ReqRepl512b      | 5000  | 3396     | 1698  | 5224   | 2612  | 1828   | 914   | 1.54    | 1.54
ReqRepl1k        | 5000  | 3767     | 3767  | 6046   | 6046  | 2279   | 2279  | 1.60    | 1.60
ReqRepl4k        | 5000  | 2483     | 9932  | 4380   | 17520 | 1897   | 7588  | 1.76    | 1.76
ReqRepl8k        | 5000  | 2106     | 16848 | 3885   | 31080 | 1779   | 14232 | 1.84    | 1.84
ReqReplAsyncNo   | 20000 | 3384     | 0     | 6778   | 0     | 3394   | 0     | 2.00    |     
ReqReplAsync8b   | 10000 | 3652     | 28    | 6750   | 52    | 3098   | 24    | 1.85    | 1.86
ReqReplAsync32b  | 10000 | 3379     | 105   | 6340   | 198   | 2961   | 93    | 1.88    | 1.89
ReqReplAsync256b | 5000  | 2659     | 664   | 5181   | 1295  | 2522   | 631   | 1.95    | 1.95
ReqReplAsync512b | 5000  | 2577     | 1288  | 5279   | 2639  | 2702   | 1351  | 2.05    | 2.05
ReqReplAsync1k   | 5000  | 3577     | 3577  | 5793   | 5793  | 2216   | 2216  | 1.62    | 1.62
ReqReplAsync4k   | 5000  | 2226     | 8904  | 4633   | 18532 | 2407   | 9628  | 2.08    | 2.08
ReqReplAsync8k   | 5000  | 1794     | 14352 | 3582   | 28656 | 1788   | 14304 | 2.00    | 2.00
```
This is an average speedup of 1.63x for sync and 1.93x for async.

`opts.UseOldRequestStyle=false`
```
                         | Baseline         | ReqReply (New) | Delta          | Speedup
-----------------|-------|----------|-------|----------------|--------|-------|---------|-----
                 | Count | msgs/s   | kb/s  | msgs/s | kb/s  | msgs/s | kb/s  | msgs/s  | kb/s
ReqReplNo        | 20000 | 4447     | 0     | 5539   | 0     | 1092   | 0     | 1.25    |     
ReqRepl8b        | 10000 | 4080     | 31    | 6760   | 52    | 2680   | 21    | 1.66    | 1.68
ReqRepl32b       | 10000 | 3905     | 122   | 5765   | 180   | 1860   | 58    | 1.48    | 1.48
ReqRepl256b      | 5000  | 3912     | 978   | 4843   | 1210  | 931    | 232   | 1.24    | 1.24
ReqRepl512b      | 5000  | 3396     | 1698  | 4476   | 2238  | 1080   | 540   | 1.32    | 1.32
ReqRepl1k        | 5000  | 3767     | 3767  | 6277   | 6277  | 2510   | 2510  | 1.67    | 1.67
ReqRepl4k        | 5000  | 2483     | 9932  | 4591   | 18364 | 2108   | 8432  | 1.85    | 1.85
ReqRepl8k        | 5000  | 2106     | 16848 | 3124   | 24992 | 1018   | 8144  | 1.48    | 1.48
ReqReplAsyncNo   | 20000 | 3384     | 0     | 7890   | 0     | 4506   | 0     | 2.33    |     
ReqReplAsync8b   | 10000 | 3652     | 28    | 7594   | 59    | 3942   | 31    | 2.08    | 2.11
ReqReplAsync32b  | 10000 | 3379     | 105   | 7272   | 227   | 3893   | 122   | 2.15    | 2.16
ReqReplAsync256b | 5000  | 2659     | 664   | 5964   | 1491  | 3305   | 827   | 2.24    | 2.25
ReqReplAsync512b | 5000  | 2577     | 1288  | 5835   | 2917  | 3258   | 1629  | 2.26    | 2.26
ReqReplAsync1k   | 5000  | 3577     | 3577  | 6290   | 6290  | 2713   | 2713  | 1.76    | 1.76
ReqReplAsync4k   | 5000  | 2226     | 8904  | 4852   | 19408 | 2626   | 10504 | 2.18    | 2.18
ReqReplAsync8k   | 5000  | 1794     | 14352 | 3994   | 31952 | 2200   | 17600 | 2.23    | 2.23
```
This is an average speedup of 1.5x for sync and 2.15x for async.